### PR TITLE
Fix: Correcoes para evitar conflitos de portas no PHPmyadmin

### DIFF
--- a/linux/superlogica-docker/v2/v2.1/subadquirente/docker-compose.yml
+++ b/linux/superlogica-docker/v2/v2.1/subadquirente/docker-compose.yml
@@ -90,6 +90,7 @@ services:
     restart: always
     ports:
      - 9080:80
+     - 10000:9000
     volumes:
      - /sessions
     networks:


### PR DESCRIPTION
Ao tentar configurar e rodar o XDEBUG na porta 9002 nos deparamos com um conflito de portas.

O problema foi corrigido ao mudar a porta do phpmyadmin.